### PR TITLE
Fix odometry calc. Joints require radian/s

### DIFF
--- a/include/tricycle_drive_controller/tricycle_drive_controller.h
+++ b/include/tricycle_drive_controller/tricycle_drive_controller.h
@@ -140,6 +140,7 @@ private:
     /// Wheel separation and radius calibration multipliers:
     double wheel_separation_multiplier_;
     double wheel_radius_multiplier_;
+    double wheel_radius_multiplier_odom_;
 
     /// Timeout to consider cmd_vel commands old:
     double ackermann_cmd_timeout_;

--- a/src/odometry.cpp
+++ b/src/odometry.cpp
@@ -138,8 +138,8 @@ Odometry::updateFromHWEncoders(double front_wheel_velocity, double front_wheel_a
     const double cos_phi = std::cos(front_wheel_angle);
     const double sin_phi = std::sin(front_wheel_angle);
 
-    const double linear = front_wheel_velocity * cos_phi;
-    const double angular = front_wheel_velocity * sin_phi / wheel_base_;
+    const double linear = front_wheel_velocity * wheel_radius_ * cos_phi;
+    const double angular = front_wheel_velocity * wheel_radius_* sin_phi / wheel_base_;
 
     double radius = 1e6;
 


### PR DESCRIPTION
- Sent m/s to joint before, however joints need radian/s, i.e. divide by
  wheel radius
- Added odometry calc factor offset for gazebo workaround